### PR TITLE
Add deprecation note to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AutoGrid for Figma
 
+> **⚠️ DEPRECATED**: This plugin is deprecated and is no longer maintained. Please consider using alternative solutions for your auto-grid needs.
+
 ## To get started
 ```bash
 npm install

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "AutoGrid",
+  "name": "AutoGrid (DEPRECATED)",
   "id": "817474150404549708",
   "api": "1.0.0",
   "main": "code.js",


### PR DESCRIPTION
Add deprecation notes to the README and manifest.json because the plugin is no longer maintained.

---
<a href="https://cursor.com/background-agent?bcId=bc-5fb79fea-3138-4f36-afb7-fb85af5deab2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5fb79fea-3138-4f36-afb7-fb85af5deab2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>

## Summary by Sourcery

Mark the AutoGrid Figma plugin as deprecated by adding deprecation notices to user-facing files.

Enhancements:
- Append "(DEPRECATED)" to the plugin name in manifest.json to reflect its deprecation status.

Documentation:
- Add a deprecation banner and note to the top of the README advising users that the plugin is no longer maintained.